### PR TITLE
feat: 긴 오디오 파일 분할 처리 기능 구현

### DIFF
--- a/ai_meeting_api/ai_meeting_meetings/serializers.py
+++ b/ai_meeting_api/ai_meeting_meetings/serializers.py
@@ -95,10 +95,10 @@ class MeetingCreateSerializer(serializers.ModelSerializer):
 
     def validate_audio_file(self, value):
         if value:
-            # 파일 크기 제한 (100MB)
-            max_size = 100 * 1024 * 1024
+            # 파일 크기 제한 (500MB) - 긴 녹음 파일 지원
+            max_size = 500 * 1024 * 1024
             if value.size > max_size:
-                raise serializers.ValidationError("음성 파일은 100MB를 초과할 수 없습니다.")
+                raise serializers.ValidationError("음성 파일은 500MB를 초과할 수 없습니다.")
 
             # 지원 포맷 확인
             allowed_extensions = [".mp3", ".wav", ".m4a", ".ogg", ".webm", ".mp4"]

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -33,7 +33,8 @@ Authorization: Bearer <access_token>
 |------|-----|
 | Access Token 유효시간 | 1시간 |
 | Refresh Token 유효시간 | 7일 |
-| 최대 음성 파일 크기 | 100MB |
+| 최대 음성 파일 크기 | 500MB |
+| 최대 녹음 길이 | 제한 없음 (25분 초과 시 서버에서 자동 분할 처리) |
 | 음성 파일 보관 기간 | 90일 |
 | 지원 오디오 형식 | `.mp3`, `.wav`, `.m4a`, `.ogg`, `.webm`, `.mp4` |
 
@@ -492,7 +493,7 @@ Authorization: Bearer <token>
 |------|------|------|------|
 | `title` | string | O | 회의 제목 |
 | `meeting_date` | datetime | O | 회의 일시 (ISO 8601) |
-| `audio_file` | file | X | 음성 파일 (최대 100MB) |
+| `audio_file` | file | X | 음성 파일 (최대 500MB) |
 
 **JavaScript 예시:**
 ```javascript
@@ -886,3 +887,4 @@ function MeetingSummary({ summary }) {
 |------|------|----------|
 | 1.0 | 2025-01-15 | 최초 작성 - Phase 4-5 완료 |
 | 1.1 | 2025-01-15 | 팀 생성 권한 변경 (인증된 사용자 모두 가능), 프로필 수정으로 팀 가입/변경 기능 문서화 |
+| 1.2 | 2025-12-12 | 긴 오디오 파일 분할 처리 기능 추가 (25분 초과 시 자동 분할), 파일 크기 제한 상향 (100MB → 500MB) |


### PR DESCRIPTION
## Summary
- 25분을 초과하는 긴 녹음 파일을 자동으로 분할하여 STT 처리 후 결과를 병합하는 기능 구현
- OpenAI gpt-4o-transcribe-diarize 모델의 25분 제한 대응
- 프론트엔드 실시간 녹음 지원을 위한 백엔드 준비 완료

## Changes
- `tasks.py`: 긴 오디오 분할 처리 로직 추가
  - `get_audio_duration()`: ffprobe로 오디오 길이 확인
  - `split_audio_ffmpeg()`: 20분 단위 분할
  - `transcribe_audio_with_split()`: 분할 STT 및 결과 병합
- `serializers.py`: 파일 크기 제한 100MB → 500MB
- `PLAN.md`: 녹음 방식 및 긴 파일 처리 기획 추가
- `API_REFERENCE.md`: 파일 크기/녹음 길이 제한 업데이트

## Test plan
- [ ] 25분 이하 오디오 파일 업로드 테스트 (기존 동작 확인)
- [ ] 30분+ 오디오 파일 업로드 테스트 (분할 처리 확인)
- [ ] 분할된 결과의 타임스탬프 연속성 확인
- [ ] 화자 데이터 병합 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)