### PR TITLE
fix: Confluence 업로드 기능 개선

### DIFF
--- a/ai_meeting_api/ai_meeting_integrations/confluence_client.py
+++ b/ai_meeting_api/ai_meeting_integrations/confluence_client.py
@@ -115,9 +115,11 @@ class ConfluenceClient:
         response.raise_for_status()
 
         data = response.json()
+        webui_path = data.get("_links", {}).get("webui", "")
+        full_url = f"{self.site_url}/wiki{webui_path}" if webui_path else ""
         return {
             "id": page_id,
-            "url": data.get("_links", {}).get("webui", ""),
+            "url": full_url,
             "version": data.get("version", {}).get("number"),
         }
 


### PR DESCRIPTION
## Summary
- 페이지 제목 형식 변경: [회의록] MMDD 제목
- 전문 화자 분리 표시 (speaker_data 활용)
- 전문 토글(expand) 매크로 적용
- 업데이트 시 URL 전체 경로 반환 수정

## Test plan
- [ ] Confluence 업로드 시 제목 형식 확인
- [ ] 화자 분리 표시 확인
- [ ] 전문 토글 기능 확인
- [ ] 업로드 후 URL 클릭 시 정상 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)